### PR TITLE
Return all query parameters if the param() method is called w/o any arguments

### DIFF
--- a/jquery.url.js
+++ b/jquery.url.js
@@ -4,171 +4,176 @@
 
 jQuery.url = function()
 {
-	var segments = {};
-	
-	var parsed = {};
-	
-	/**
+  var segments = {};
+
+  var parsed = {};
+
+  /**
     * Options object. Only the URI and strictMode values can be changed via the setters below.
     */
-  	var options = {
-	
-		url : window.location, // default URI is the page in which the script is running
-		
-		strictMode: false, // 'loose' parsing by default
-	
-		key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"], // keys available to query 
-		
-		q: {
-			name: "queryKey",
-			parser: /(?:^|&)([^&=]*)=?([^&]*)/g
-		},
-		
-		parser: {
-			strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,  //less intuitive, more accurate to the specs
-			loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/ // more intuitive, fails on relative paths and deviates from specs
-		}
-		
-	};
-	
+    var options = {
+
+    url : window.location, // default URI is the page in which the script is running
+
+    strictMode: false, // 'loose' parsing by default
+
+    key: ["source","protocol","authority","userInfo","user","password","host","port","relative","path","directory","file","query","anchor"], // keys available to query
+
+    q: {
+      name: "queryKey",
+      parser: /(?:^|&)([^&=]*)=?([^&]*)/g
+    },
+
+    parser: {
+      strict: /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,  //less intuitive, more accurate to the specs
+      loose:  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/ // more intuitive, fails on relative paths and deviates from specs
+    }
+
+  };
+
     /**
      * Deals with the parsing of the URI according to the regex above.
- 	 * Written by Steven Levithan - see credits at top.
-     */		
-	var parseUri = function()
-	{
-		str = decodeURI( options.url );
-		
-		var m = options.parser[ options.strictMode ? "strict" : "loose" ].exec( str );
-		var uri = {};
-		var i = 14;
+    * Written by Steven Levithan - see credits at top.
+     */
+  var parseUri = function()
+  {
+    str = decodeURI( options.url );
 
-		while ( i-- ) {
-			uri[ options.key[i] ] = m[i] || "";
-		}
+    var m = options.parser[ options.strictMode ? "strict" : "loose" ].exec( str );
+    var uri = {};
+    var i = 14;
 
-		uri[ options.q.name ] = {};
-		uri[ options.key[12] ].replace( options.q.parser, function ( $0, $1, $2 ) {
-			if ($1) {
-				uri[options.q.name][$1] = $2;
-			}
-		});
+    while ( i-- ) {
+      uri[ options.key[i] ] = m[i] || "";
+    }
 
-		return uri;
-	};
+    uri[ options.q.name ] = {};
+    uri[ options.key[12] ].replace( options.q.parser, function ( $0, $1, $2 ) {
+      if ($1) {
+        uri[options.q.name][$1] = $2;
+      }
+    });
+
+    return uri;
+  };
 
     /**
      * Returns the value of the passed in key from the parsed URI.
-  	 * 
-	 * @param string key The key whose value is required
-     */		
-	var key = function( key )
-	{
-		if ( jQuery.isEmptyObject(parsed) )
-		{
-			setUp(); // if the URI has not been parsed yet then do this first...	
-		} 
-		if ( key == "base" )
-		{
-			if ( parsed.port !== null && parsed.port !== "" )
-			{
-				return parsed.protocol+"://"+parsed.host+":"+parsed.port+"/";	
-			}
-			else
-			{
-				return parsed.protocol+"://"+parsed.host+"/";
-			}
-		}
-	
-		return ( parsed[key] === "" ) ? null : parsed[key];
-	};
-	
-	/**
+     *
+   * @param string key The key whose value is required
+     */
+  var key = function( key )
+  {
+    if ( jQuery.isEmptyObject(parsed) )
+    {
+      setUp(); // if the URI has not been parsed yet then do this first...
+    }
+    if ( key == "base" )
+    {
+      if ( parsed.port !== null && parsed.port !== "" )
+      {
+        return parsed.protocol+"://"+parsed.host+":"+parsed.port+"/";
+      }
+      else
+      {
+        return parsed.protocol+"://"+parsed.host+"/";
+      }
+    }
+
+    return ( parsed[key] === "" ) ? null : parsed[key];
+  };
+
+  /**
      * Returns the value of the required query string parameter.
-  	 * 
-	 * @param string item The parameter whose value is required
-     */		
-	var param = function( item )
-	{
-		if ( jQuery.isEmptyObject(parsed) )
-		{
-			setUp(); // if the URI has not been parsed yet then do this first...	
-		}
-		return ( parsed.queryKey[item] === null ) ? null : parsed.queryKey[item];
-	};
+     *
+   * @param string item The parameter whose value is required
+     */
+  var param = function( item )
+  {
+    if ( jQuery.isEmptyObject(parsed) )
+    {
+      setUp(); // if the URI has not been parsed yet then do this first...
+    }
+
+    if(item === undefined){
+      return parsed.queryKey;
+    }else{
+      return ( parsed.queryKey[item] === null ) ? null : parsed.queryKey[item];
+    }
+  };
 
     /**
      * 'Constructor' (not really!) function.
-     *  Called whenever the URI changes to kick off re-parsing of the URI and splitting it up into segments. 
-     */	
-	var setUp = function()
-	{
-		parsed = parseUri();
-		
-		getSegments();	
-	};
-	
+     *  Called whenever the URI changes to kick off re-parsing of the URI and splitting it up into segments.
+     */
+  var setUp = function()
+  {
+    parsed = parseUri();
+
+    getSegments();
+  };
+
     /**
      * Splits up the body of the URI into segments (i.e. sections delimited by '/')
      */
-	var getSegments = function()
-	{
-		var p = parsed.path;
-		segments = []; // clear out segments array
-		segments = parsed.path.length == 1 ? {} : ( p.charAt( p.length - 1 ) == "/" ? p.substring( 1, p.length - 1 ) : path = p.substring( 1 ) ).split("/");
-	};
-	
-	return {
-		
-	    /**
-	     * Sets the parsing mode - either strict or loose. Set to loose by default.
-	     *
-	     * @param string mode The mode to set the parser to. Anything apart from a value of 'strict' will set it to loose!
-	     */
-		setMode : function( mode )
-		{
-			options.strictMode = mode == "strict" ? true : false;
-			return this;
-		},
-		
-		/**
-	     * Sets URI to parse if you don't want to to parse the current page's URI.
-		 * Calling the function with no value for newUri resets it to the current page's URI.
-	     *
-	     * @param string newUri The URI to parse.
-	     */		
-		setUrl : function( newUri )
-		{
-			options.url = newUri === undefined ? window.location : newUri;
-			setUp();
-			return this;
-		},		
-		
-		/**
-	     * Returns the value of the specified URI segment. Segments are numbered from 1 to the number of segments.
-		 * For example the URI http://test.com/about/company/ segment(1) would return 'about'.
-		 *
-		 * If no integer is passed into the function it returns the number of segments in the URI.
-	     *
-	     * @param int pos The position of the segment to return. Can be empty.
-	     */	
-		segment : function( pos )
-		{
-			if ( jQuery.isEmptyObject(parsed) )
-			{
-				setUp(); // if the URI has not been parsed yet then do this first...	
-			} 
-			if ( pos === undefined )
-			{
-				return segments.length;
-			}
-			return ( segments[pos] === "" || segments[pos] === undefined ) ? null : segments[pos];
-		},
-		
-		attr : key, // provides public access to private 'key' function - see above
-		
-		param : param // provides public access to private 'param' function - see above
-		
-	};
-	
+  var getSegments = function()
+  {
+    var p = parsed.path;
+    segments = []; // clear out segments array
+    segments = parsed.path.length == 1 ? {} : ( p.charAt( p.length - 1 ) == "/" ? p.substring( 1, p.length - 1 ) : path = p.substring( 1 ) ).split("/");
+  };
+
+  return {
+
+      /**
+       * Sets the parsing mode - either strict or loose. Set to loose by default.
+       *
+       * @param string mode The mode to set the parser to. Anything apart from a value of 'strict' will set it to loose!
+       */
+    setMode : function( mode )
+    {
+      options.strictMode = mode == "strict" ? true : false;
+      return this;
+    },
+
+    /**
+       * Sets URI to parse if you don't want to to parse the current page's URI.
+     * Calling the function with no value for newUri resets it to the current page's URI.
+       *
+       * @param string newUri The URI to parse.
+       */
+    setUrl : function( newUri )
+    {
+      options.url = newUri === undefined ? window.location : newUri;
+      setUp();
+      return this;
+    },
+
+    /**
+       * Returns the value of the specified URI segment. Segments are numbered from 1 to the number of segments.
+     * For example the URI http://test.com/about/company/ segment(1) would return 'about'.
+     *
+     * If no integer is passed into the function it returns the number of segments in the URI.
+       *
+       * @param int pos The position of the segment to return. Can be empty.
+       */
+    segment : function( pos )
+    {
+      if ( jQuery.isEmptyObject(parsed) )
+      {
+        setUp(); // if the URI has not been parsed yet then do this first...
+      }
+      if ( pos === undefined )
+      {
+        return segments.length;
+      }
+      return ( segments[pos] === "" || segments[pos] === undefined ) ? null : segments[pos];
+    },
+
+    attr : key, // provides public access to private 'key' function - see above
+
+    param : param // provides public access to private 'param' function - see above
+
+  };
+
 }();


### PR DESCRIPTION
Unfortunately, I've got my editor setup to replace all tabs w/spaces, so this commit may appear to have more functional changes than it actually does. The only code change is the important bit here: https://github.com/peburrows/jQuery-URL-Parser/blob/60340dc1860509d244ece64f877b5007cc2e06eb/jquery.url.js#L98-102
