### PR TITLE
Fix query decoding issue

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -29,7 +29,7 @@ var purl = (function(undefined) {
 	
 	function parseUri( url, strictMode )
 	{
-		var str = decodeURI( url ),
+		var str = url,
 		    res   = parser[ strictMode || false ? "strict" : "loose" ].exec( str ),
 		    uri = { attr : {}, param : {}, seg : {} },
 		    i   = 14;
@@ -47,23 +47,25 @@ var purl = (function(undefined) {
 		uri.attr['query'].replace( querystring_parser, function ( $0, $1, $2 ){
 			if ($1)
 			{
-				uri.param['query'][$1] = $2;
+				uri.param['query'][$1] = decodeURIComponent($2);
 			}
 		});
 		
 		uri.attr['fragment'].replace( fragment_parser, function ( $0, $1, $2 ){
 			if ($1)
 			{
-				uri.param['fragment'][$1] = $2;
+				uri.param['fragment'][$1] = decodeURIComponent($2);
 			}
 		});
 				
 		// split path and fragement into segments
 		
-        uri.seg['path'] = uri.attr.path.replace(/^\/+|\/+$/g,'').split('/');
+        uri.seg['path'] = uri.attr.path.replace(/^\/+|\/+$/g,'').split('/').map(function(part) {return decodeURIComponent(part);});
         
-        uri.seg['fragment'] = uri.attr.fragment.replace(/^\/+|\/+$/g,'').split('/');
+        uri.seg['fragment'] = uri.attr.fragment.replace(/^\/+|\/+$/g,'').split('/').map(function(part) {return decodeURIComponent(part);});
         
+        uri.attr.host = uri.attr.host ? decodeURI(uri.attr.host) : ''; // International URLs
+
         // compile a 'base' domain attribute
         
         uri.attr['base'] = uri.attr.host ? uri.attr.protocol+"://"+uri.attr.host + (uri.attr.port ? ":"+uri.attr.port : '') : '';


### PR DESCRIPTION
_This is not necessarily a completely correct solution, just want to send so there can be a discussion abut the issue_

decodeURI was called too early and while it works for the host and path, it messes up the query parameters of an url, making it impossible to decode that part correctly.

E.g. as in the test below, the query string `Test%20%231` was before returned as `Test %231`, instead of the expected `Test #1`. This issue cannot be fixed by the clients, running decodeURIComponent again, since for strings that include the encoded % sign it will result in an error: `The%25sign` gets returned as `The%sign`, and cannot handled in the same way as the previous example of `Test %231` which would be corrected by a second decoding.

This patch instead calls decodeURIComponent on the parts of the url separately at the last possible time to ensure proper decoding.

The host, path, query and fragment parts are affected.

Can test it with this html:

```
<html>
<head>
<script src="purl.js"></script>
<script>
  var noteURL = 'http://test.com/?title=Test%20%231';
  var url = purl(noteURL);
  document.write('Test URL: '+noteURL+'<br />');
  document.write('returned \'title\' query parameter is: <b>'+url.param('title')+'</b><br />');
  document.write('returned \'title\' query should be: <b>Test #1</b><br />');
</script>
</head>
<body>
</body>
</html>
```

The jQuery version is also affected the same way.
