### PR TITLE
Add AMD with fallback

### DIFF
--- a/jquery.url.js
+++ b/jquery.url.js
@@ -5,8 +5,15 @@
  * Licensed under an MIT-style license. See https://github.com/allmarkedup/jQuery-URL-Parser/blob/master/LICENSE for details.
  */ 
 
-;(function($, undefined) {
-    
+;(function(factory) {
+    if (typeof define === 'function' && define.amd) {
+        // AMD available; use anonymous module
+        define(['jquery'], factory);
+    } else {
+        // No AMD available; mutate global vars
+        factory(jQuery);
+    }
+})(function($, undefined) {
     var tag2attr = {
         a       : 'href',
         img     : 'src',
@@ -159,4 +166,5 @@
         
 	};
 	
-})(jQuery);
+});
+


### PR DESCRIPTION
Hi, I've been porting a project to use RequireJS and have modified this plugin to use AMD defines. It is a very unobtrusive and backwards-compatible change, so I hope you will incorporate it.

Here is the basic pattern I followed: https://github.com/umdjs/umd/blob/master/jqueryPlugin.js
