### PR TITLE
base generation

### DIFF
--- a/jquery.url.js
+++ b/jquery.url.js
@@ -69,7 +69,7 @@
         
         // compile a 'base' domain attribute
         
-        uri.attr['base'] = uri.attr.host ? uri.attr.protocol+"://"+uri.attr.host + (uri.attr.port ? ":"+uri.attr.port : '') : '';
+        uri.attr['base'] = uri.attr.host ? (uri.attr.protocol ?  uri.attr.protocol+"://"+uri.attr.host : uri.attr.host) + (uri.attr.port ? ":"+uri.attr.port : '') : '';
         
 		return uri;
 	};


### PR DESCRIPTION
Hi,

for a project I altered attr['base'] to get less faulty urls.

uri.attr['base'] = uri.attr.host ? (uri.attr.protocol ?  uri.attr.protocol+"://"+uri.attr.host : uri.attr.host) + (uri.attr.port ? ":"+uri.attr.port : '') : '';

Thanks for your plugin.
