### PR TITLE
support requesting specific set of parameters

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -1,5 +1,5 @@
 /*
- * JQuery URL Parser plugin, v2.2.1
+ * JQuery URL Parser plugin, v2.2.1.2
  * Developed and maintanined by Mark Perkins, mark@allmarkedup.com
  * Source repository: https://github.com/allmarkedup/jQuery-URL-Parser
  * Licensed under an MIT-style license. See https://github.com/allmarkedup/jQuery-URL-Parser/blob/master/LICENSE for details.


### PR DESCRIPTION
- add support for requesting specific parameters only, by an array of parameter names. The returned parameters are in the same format as they were previously; an associative array for multiple parameters, a single value for a single parameter, and an array as the values if there are multiple values for a given parameter
