### PR TITLE
Fix #51 where .param() should return an empty object

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -3,13 +3,13 @@
  * Developed and maintanined by Mark Perkins, mark@allmarkedup.com
  * Source repository: https://github.com/allmarkedup/jQuery-URL-Parser
  * Licensed under an MIT-style license. See https://github.com/allmarkedup/jQuery-URL-Parser/blob/master/LICENSE for details.
- */ 
+ */
 
 ;(function(factory) {
 	if (typeof define === 'function' && define.amd) {
 		// AMD available; use anonymous module
 		if ( typeof jQuery !== 'undefined' ) {
-			define(['jquery'], factory);	
+			define(['jquery'], factory);
 		} else {
 			define([], factory);
 		}
@@ -22,7 +22,7 @@
 		}
 	}
 })(function($, undefined) {
-	
+
 	var tag2attr = {
 			a       : 'href',
 			img     : 'src',
@@ -32,50 +32,50 @@
 			iframe  : 'src',
 			link    : 'href'
 		},
-		
+
 		key = ['source', 'protocol', 'authority', 'userInfo', 'user', 'password', 'host', 'port', 'relative', 'path', 'directory', 'file', 'query', 'fragment'], // keys available to query
-		
+
 		aliases = { 'anchor' : 'fragment' }, // aliases for backwards compatability
-		
+
 		parser = {
 			strict : /^(?:([^:\/?#]+):)?(?:\/\/((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?))?((((?:[^?#\/]*\/)*)([^?#]*))(?:\?([^#]*))?(?:#(.*))?)/,  //less intuitive, more accurate to the specs
 			loose :  /^(?:(?![^:@]+:[^:@\/]*@)([^:\/?#.]+):)?(?:\/\/)?((?:(([^:@]*):?([^:@]*))?@)?([^:\/?#]*)(?::(\d*))?)(((\/(?:[^?#](?![^?#\/]*\.[^?#\/.]+(?:[?#]|$)))*\/?)?([^?#\/]*))(?:\?([^#]*))?(?:#(.*))?)/ // more intuitive, fails on relative paths and deviates from specs
 		},
-		
+
 		toString = Object.prototype.toString,
-		
+
 		isint = /^[0-9]+$/;
-	
+
 	function parseUri( url, strictMode ) {
 		var str = decodeURI( url ),
 		res   = parser[ strictMode || false ? 'strict' : 'loose' ].exec( str ),
 		uri = { attr : {}, param : {}, seg : {} },
 		i   = 14;
-		
+
 		while ( i-- ) {
 			uri.attr[ key[i] ] = res[i] || '';
 		}
-		
-		// build query and fragment parameters		
+
+		// build query and fragment parameters
 		uri.param['query'] = parseString(uri.attr['query']);
 		uri.param['fragment'] = parseString(uri.attr['fragment']);
-		
-		// split path and fragement into segments		
-		uri.seg['path'] = uri.attr.path.replace(/^\/+|\/+$/g,'').split('/');     
+
+		// split path and fragement into segments
+		uri.seg['path'] = uri.attr.path.replace(/^\/+|\/+$/g,'').split('/');
 		uri.seg['fragment'] = uri.attr.fragment.replace(/^\/+|\/+$/g,'').split('/');
-		
-		// compile a 'base' domain attribute        
-		uri.attr['base'] = uri.attr.host ? (uri.attr.protocol ?  uri.attr.protocol+'://'+uri.attr.host : uri.attr.host) + (uri.attr.port ? ':'+uri.attr.port : '') : '';      
-		  
+
+		// compile a 'base' domain attribute
+		uri.attr['base'] = uri.attr.host ? (uri.attr.protocol ?  uri.attr.protocol+'://'+uri.attr.host : uri.attr.host) + (uri.attr.port ? ':'+uri.attr.port : '') : '';
+
 		return uri;
 	}
-	
+
 	function getAttrName( elm ) {
 		var tn = elm.tagName;
 		if ( typeof tn !== 'undefined' ) return tag2attr[tn.toLowerCase()];
 		return tn;
 	}
-	
+
 	function promote(parent, key) {
 		if (parent[key].length === 0) return parent[key] = {};
 		var t = {};
@@ -130,7 +130,9 @@
 				for (var k in parent.base) t[k] = parent.base[k];
 				parent.base = t;
 			}
-			set(parent.base, key, val);
+			if (key !== '') {
+				set(parent.base, key, val);
+			}
 		}
 		return parent;
 	}
@@ -147,7 +149,7 @@
 				key = pair.substr(0, brace || eql),
 				val = pair.substr(brace || eql, pair.length);
 
-				val = val.substr(val.indexOf('=') + 1, val.length);
+			val = val.substr(val.indexOf('=') + 1, val.length);
 
 			if (key === '') {
 				key = pair;
@@ -157,7 +159,7 @@
 			return merge(ret, key, val);
 		}, { base: {} }).base;
 	}
-	
+
 	function set(obj, key, val) {
 		var v = obj[key];
 		if (undefined === v) {
@@ -168,7 +170,7 @@
 			obj[key] = [v, val];
 		}
 	}
-	
+
 	function lastBraceInKey(str) {
 		var len = str.length,
 			brace,
@@ -180,7 +182,7 @@
 			if ('=' == c && !brace) return i;
 		}
 	}
-	
+
 	function reduce(obj, accumulator){
 		var i = 0,
 			l = obj.length >> 0,
@@ -191,11 +193,11 @@
 		}
 		return curr;
 	}
-	
+
 	function isArray(vArg) {
 		return Object.prototype.toString.call(vArg) === "[object Array]";
 	}
-	
+
 	function keys(obj) {
 		var key_array = [];
 		for ( var prop in obj ) {
@@ -203,7 +205,7 @@
 		}
 		return key_array;
 	}
-		
+
 	function purl( url, strictMode ) {
 		if ( arguments.length === 1 && url === true ) {
 			strictMode = true;
@@ -211,63 +213,63 @@
 		}
 		strictMode = strictMode || false;
 		url = url || window.location.toString();
-	
+
 		return {
-			
+
 			data : parseUri(url, strictMode),
-			
+
 			// get various attributes from the URI
 			attr : function( attr ) {
 				attr = aliases[attr] || attr;
 				return typeof attr !== 'undefined' ? this.data.attr[attr] : this.data.attr;
 			},
-			
+
 			// return query string parameters
 			param : function( param ) {
 				return typeof param !== 'undefined' ? this.data.param.query[param] : this.data.param.query;
 			},
-			
+
 			// return fragment parameters
 			fparam : function( param ) {
 				return typeof param !== 'undefined' ? this.data.param.fragment[param] : this.data.param.fragment;
 			},
-			
+
 			// return path segments
 			segment : function( seg ) {
 				if ( typeof seg === 'undefined' ) {
 					return this.data.seg.path;
 				} else {
 					seg = seg < 0 ? this.data.seg.path.length + seg : seg - 1; // negative segments count from the end
-					return this.data.seg.path[seg];                    
+					return this.data.seg.path[seg];
 				}
 			},
-			
+
 			// return fragment segments
 			fsegment : function( seg ) {
 				if ( typeof seg === 'undefined' ) {
-					return this.data.seg.fragment;                    
+					return this.data.seg.fragment;
 				} else {
 					seg = seg < 0 ? this.data.seg.fragment.length + seg : seg - 1; // negative segments count from the end
-					return this.data.seg.fragment[seg];                    
+					return this.data.seg.fragment[seg];
 				}
 			}
-	    	
+
 		};
-	
+
 	}
-	
+
 	if ( typeof $ !== 'undefined' ) {
-		
+
 		$.fn.url = function( strictMode ) {
 			var url = '';
 			if ( this.length ) {
 				url = $(this).attr( getAttrName(this[0]) ) || '';
-			}    
+			}
 			return purl( url, strictMode );
 		};
-		
+
 		$.url = purl;
-		
+
 	} else {
 		window.purl = purl;
 	}

--- a/test/purl-tests.js
+++ b/test/purl-tests.js
@@ -64,9 +64,17 @@ testSuite = function(url) {
     });
 };
 
+testEmptyQueryParams = function(url) {
+    it('should have empty param()', function() {
+        expect(Object.keys( url.param() ).length === 0).toBeTrue();
+    });
+};
+
 describe("purl in non-strict mode", function () {
 
     testSuite(purl('http://allmarkedup.com/folder/dir/index.html?item=value#foo'));
+    testEmptyQueryParams(purl('http://allmarkedup.com/folder/dir/index.html#foo'));
+    testEmptyQueryParams(purl('http://allmarkedup.com/folder/dir/index.html?#foo'));
 
 });
 
@@ -74,5 +82,7 @@ describe("purl in non-strict mode", function () {
 describe("purl in strict mode", function () {
 
     testSuite(purl('http://allmarkedup.com/folder/dir/index.html?item=value#foo', true));
+    testEmptyQueryParams(purl('http://allmarkedup.com/folder/dir/index.html#foo', true));
+    testEmptyQueryParams(purl('http://allmarkedup.com/folder/dir/index.html?#foo', true));
 
 });


### PR DESCRIPTION
The problem is described in #51.

_Broken:_ `purl('foo').param()` returned `Object { = ""}`
_Fixed:_ `purl('foo').param()` now returns `Object {}`

The first commit is just addressing semicolons, equal testing and related things that JSHint yelled about. The actual fix and tests are in the second commit. However lots of whitespace trimming also made it through (because I forgot I was ignoring it) so here's a better diff view:
[https://github.com/joncotton/jQuery-URL-Parser/commit/56602811825c9612e6d992e847faabdbfea9ff33?w=1](https://github.com/joncotton/jQuery-URL-Parser/commit/56602811825c9612e6d992e847faabdbfea9ff33?w=1)
