### PR TITLE
Fix for AMD Support

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -267,5 +267,7 @@
 		window.purl = purl;
 	}
 
+	return purl;
+
 });
 


### PR DESCRIPTION
It doesn't look like purl will actually work with an AMD loader right now since the factory doesn't actually return the module.

This adds a return statement (:
