### PR TITLE
Make Compatible w/ r.js Optimizer

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -8,22 +8,15 @@
 ;(function(factory) {
 	if (typeof define === 'function' && define.amd) {
 		// AMD available; use anonymous module
-		if ( typeof jQuery !== 'undefined' ) {
-			define(['jquery'], factory);	
-		} else {
-			define([], factory);
-		}
+		define(function () { return factory(); });
 	} else {
 		// No AMD available; mutate global vars
-		if ( typeof jQuery !== 'undefined' ) {
-			factory(jQuery);
-		} else {
-			factory();
-		}
+		factory();
 	}
-})(function($, undefined) {
-	
-	var tag2attr = {
+})(function(undefined) {
+	var
+		$ = window.jQuery,
+		tag2attr = {
 			a       : 'href',
 			img     : 'src',
 			form    : 'action',


### PR DESCRIPTION
This is the fix for #59.

If used with require.js/AMD, it no longer attempts to extend jQuery. I don't know of any way around this; AFAIK either jQuery has to be a dependency or not. The old code would check for the existence of the global jQuery object and alter behavior, making it dependent on loading order and therefore susceptible to mysterious (and random) breakage.
