### PR TITLE
Allow purl to eval in a non-browser environment

### DIFF
--- a/purl.js
+++ b/purl.js
@@ -9,7 +9,7 @@
     if (typeof define === 'function' && define.amd) {
         define(factory);
     } else {
-        window.purl = factory();
+        this.purl = factory();
     }
 })(function() {
 
@@ -260,7 +260,9 @@
         }
     };
 
-    purl.jQuery(window.jQuery);
+    if ( typeof window !== 'undefined' ) {
+        purl.jQuery(window.jQuery);    
+    }
 
     return purl;
 


### PR DESCRIPTION
During the build process of a project I'm working on, purl gets evaled by https://github.com/jrburke/r.js, which is running on node, and as such there is no window object.

This commit makes some very small changes to allow purl to eval and to work on a non-browser environment, namely it does not require `window` to exist.
