### PR TITLE
Add package.json file, to make purl installable through npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+    "author": "allmarkedup",
+    "name": "purl-parser",
+    "version": "2.3.1",
+    "description": "An AMD compatible utility to parse urls and provide easy access to their attributes (such as the protocol, host, port etc), path segments, querystring parameters, fragment parameters and more.",
+    "main": "purl.js",
+    "repository": {
+        "type": "git",
+        "url": "https://github.com/allmarkedup/purl"
+    },
+    "license": "MIT"
+}


### PR DESCRIPTION
The package name is purl-parser, because the name purl was already
taken in the npm registry.
